### PR TITLE
A pool of threads approach for increasing the FPS on client

### DIFF
--- a/Client.java
+++ b/Client.java
@@ -49,7 +49,8 @@ public class Client extends Thread {
 				BufferedImage img = ImageIO.read(new ByteArrayInputStream(byteImg)); // converting the bytes into an image
 
 				// showing the image on the GUI
-				gui.jl.setIcon(new ImageIcon(img)); // reference: https://github.com/Imran92/Java-UDP-Video-Stream-Server/blob/master/src/java_video_stream/JavaClient.java#L149
+				if (img != null)
+					gui.jl.setIcon(new ImageIcon(img)); // reference: https://github.com/Imran92/Java-UDP-Video-Stream-Server/blob/master/src/java_video_stream/JavaClient.java#L149
 				frame.repaint();
 
 				Thread.sleep(15);

--- a/ScreenPrinter.java
+++ b/ScreenPrinter.java
@@ -1,0 +1,61 @@
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Queue;
+
+public class ScreenPrinter extends Thread {
+
+    public static Queue<byte[]> imgQueue;
+    public int sleepTime;
+    private Robot rb;
+    private Rectangle screen;
+
+    public ScreenPrinter(Queue<byte[]> imgQueue, int sleepTime) throws Exception {
+        this.imgQueue = imgQueue;
+        this.sleepTime = sleepTime;
+        this.rb = new Robot(); // reference: https://github.com/Imran92/Java-UDP-Video-Stream-Server/blob/master/src/java_video_stream/JavaServer.java#L151
+        this.screen = new Rectangle(Toolkit.getDefaultToolkit().getScreenSize());
+    }
+
+    public static void startScreenshots(int nThreads, int sleepTime, Queue<byte[]> queue) throws Exception{
+        Thread[] printers = new ScreenPrinter[nThreads];
+        for (int i = 0; i < nThreads; i++) {
+            printers[i] = new ScreenPrinter(queue, sleepTime);
+        }
+
+        for (Thread printer : printers) {
+            printer.start();
+            Thread.sleep(sleepTime);
+        }
+    }
+
+    public void run() {
+        while(true) {
+            try {
+
+                // reference: https://stackoverflow.com/questions/19839172/how-to-read-all-of-inputstream-in-server-socket-java
+                BufferedImage screenshot = rb.createScreenCapture(screen); // getting the screenshot
+
+                // converting the screenshot into bytes
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ImageIO.write(screenshot, "jpeg", baos);
+
+                if (baos != null) {
+                    byte[] byteImg = baos.toByteArray();
+                    imgQueue.add(byteImg);
+                }
+
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            try {
+                Thread.sleep(sleepTime);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/Server.java
+++ b/Server.java
@@ -1,68 +1,62 @@
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.awt.*;
 import java.net.*;
 import java.io.*;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Queue;
 
 public class Server extends Thread {
 	private static ServerSocket serverSocket;
 	private static ArrayList<DataOutputStream> clientsOut; // used for sending messages to all clients
-	private Socket server;
-	private DataInputStream in;
+	private static ArrayList<DataInputStream> clientsIn;
+	public static Queue<byte[]> imgQueue;
 
-	public Server(Socket server) {
-   		this.server = server;
-   		try {
-        	this.in = new DataInputStream(server.getInputStream());
-		} catch (IOException e) {
-        	e.printStackTrace();
+	synchronized public void run() {
+
+		while (true) {
+
+			byte[] byteImg = imgQueue.poll();
+			if (byteImg != null) {
+				for (Iterator<DataOutputStream> it = clientsOut.iterator(); it.hasNext(); ) {
+					DataOutputStream out = it.next();
+					try {
+						out.writeInt(byteImg.length); // sending the size of the image
+						out.write(byteImg); // sending the image // reference: https://stackoverflow.com/questions/25086868/how-to-send-images-through-sockets-in-java
+						out.flush(); // forcing to write in the socket everything on the DataOutputStream buffer
+					} catch (IOException ioException) {
+						it.remove();
+						ioException.printStackTrace();
+					}
+				}
+			}
+
+			try {
+				Thread.sleep(15);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+
 		}
 	}
-
-	public void run() {
-    	try {
-			DataOutputStream out = new DataOutputStream(server.getOutputStream());
-			clientsOut.add(out);
-			Robot rb = new Robot(); // reference: https://github.com/Imran92/Java-UDP-Video-Stream-Server/blob/master/src/java_video_stream/JavaServer.java#L151
-			while (true) {
-				// reference: https://stackoverflow.com/questions/19839172/how-to-read-all-of-inputstream-in-server-socket-java
-				BufferedImage screenshot = new Robot().createScreenCapture(new Rectangle(Toolkit.getDefaultToolkit().getScreenSize())); // getting the screenshot
-
-				// converting the screenshot into bytes
-				ByteArrayOutputStream baos = new ByteArrayOutputStream();
-				ImageIO.write(screenshot,"jpeg",baos);
-				byte[] byteImg  = baos.toByteArray();
-
-				out.writeInt(byteImg.length); // sending the size of the image
-				out.write(byteImg); // sending the image // reference: https://stackoverflow.com/questions/25086868/how-to-send-images-through-sockets-in-java
-				out.flush(); // forcing to write in the socket everything on the DataOutputStream buffer
-
-				Thread.sleep(15);
-			}
-   		}
-   		catch(Exception e) {
-   			e.printStackTrace();
-   		}
-	}
    
-	public static void main(String [] args) {
+	synchronized public static void main(String [] args) {
 		int port = 12345;
 		try {
 			serverSocket = new ServerSocket(port);
 			clientsOut = new ArrayList<DataOutputStream>();
+			imgQueue = new LinkedList<byte[]>();
+			ScreenPrinter.startScreenshots(3,15,imgQueue);
+			Thread t = new Server();
+			t.start();
 
 			while(true) { // reference: https://stackoverflow.com/questions/10131377/socket-programming-multiple-client-to-one-server
 				System.out.println("Waiting for client on port " + serverSocket.getLocalPort() + "...");
 				Socket server = serverSocket.accept();
 				System.out.println("Just connected to " + server.getRemoteSocketAddress());
-				Thread t = new Server(server);
-        		t.start();
+				clientsOut.add(new DataOutputStream(server.getOutputStream()));
 			}
 
-		} catch (IOException e) {
+		} catch (Exception e) {
         	e.printStackTrace();
     	}
 	}


### PR DESCRIPTION
An attempt of increasing the number of frames per second captured from the screen using multithreading.
TODO: analyze the time spent by the printer threads and estipulate an unreachable maximum for standardizing the time between each print. Doing so is expected a smoother experience with non-variable fps at the server level.